### PR TITLE
Add/scheduled builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,55 @@ version: 2.1
 
 workflows:
   version: 2
-  test:
+
+  # The build workflow will build a preview for the site, intended for PRs
+  build:
     jobs:
-      - build-python-3:
+      - build-site:
           filters:
             branches:
               ignore: master
+
+  # The build nightly has a content (below) that indicates deployment
+  build-nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-site:
+          context: trigger-context
+          filters:
+            branches:
+              only:
+                - master
 
 install: &install
   name: install dependencies for build
   command: |
      $HOME/conda/bin/pip install -r ~/repo/.circleci/requirements.txt
+
+deploy: &deploy
+  name: Deploy back to GitHub master, only in the case that CIRCLECI_TRIGGER is found
+  command: |
+    # Only deploy if the CIRCLECI_TRIGGER is found in the environment
+    if [ -z "$CIRCLECI_TRIGGER" ]; then
+        echo "CIRCLECI_TRIGGER not found, not nightly build, will not deploy."
+        exit 0
+    else
+        echo "Detected trigger, updating GitHub pages!"    
+        git config user.name "${CIRCLE_USERNAME}"
+        git config user.email "${CIRCLE_USERNAME}@users.noreply.github.com"
+        git checkout master
+        git pull origin master
+        git add ~/repo/_posts/*
+        git commit -m 'Automated deployment to Github Pages' --allow-empty
+        git push origin master
+    fi      
+
 
 install_python_3: &install_python_3
   name: install Python 3.5 dependencies
@@ -44,7 +82,7 @@ build_jekyll: &build_jekyll
         bundle exec jekyll build
 
 jobs:
-  build-python-3:
+  build-site:
     docker:
       - image: circleci/ruby:2.4.1
     working_directory: ~/repo
@@ -78,3 +116,4 @@ jobs:
       - store_artifacts:
           path: ~/repo/_site
           destination: blog
+      - run: *deploy

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# U.S. Research Software Engineer Blog 
-
-[![CircleCI](https://circleci.com/gh/USRSE/blog.svg?style=svg)](https://circleci.com/gh/USRSE/blog)
+# U.S. Research Software Engineer Blog
 
 This is a syndicated blog to provide content for research software engineers
 across the United States. Here they can add an rss/xml feed to share stories

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Us RSE Blog 
+# U.S. Research Software Engineer Blog 
+
+[![CircleCI](https://circleci.com/gh/USRSE/blog.svg?style=svg)](https://circleci.com/gh/USRSE/blog)
 
 This is a syndicated blog to provide content for research software engineers
 across the United States. Here they can add an rss/xml feed to share stories


### PR DESCRIPTION
This will be a first go at enabling automated nightly builds. Specifically:

 - we add a build context that will define an envar to be found that is associated with the "nightly-build" job that is only triggered by cron. The helpful advice came from [here](https://twitter.com/vsoch/status/1128006624482926594)!
 - the build context is created under the Project -> Org -> Settings. It's a trivial variable called `CIRCLECI_TRIGGER` that is set to on (and it doesn't really matter, as long as it is found).

I don't think there is a reasonable way to test this until the trigger, and then we can see if it works :) 