### PR TITLE
updating header color to match branding of usrse site

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -70,7 +70,7 @@ img::-moz-selection {
 #mainNav {
   position: absolute;
   border-bottom: 1px solid #e9ecef;
-  background-color: white;
+  background-color: #e7e7e7 !important;
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; }
   #mainNav .navbar-brand {
     font-weight: 800;
@@ -120,7 +120,7 @@ img::-moz-selection {
         -moz-transition: -moz-transform 0.2s;
         transition: transform 0.2s;
         border-bottom: 1px solid white;
-        background-color: #2196F3; }
+        background-color: #e7e7e7; }
         #mainNav.is-fixed .navbar-brand {
           color: white; }
           #mainNav.is-fixed .navbar-brand:focus, #mainNav.is-fixed .navbar-brand:hover {


### PR DESCRIPTION
This is a quick PR to update the header color for this blog site, specifically so it better matches the branding of main usrse site.

The only change is adjusting the color of the header to be the same grey.

![image](https://user-images.githubusercontent.com/814322/57730807-42723200-7667-11e9-865c-e8ac69158e41.png)

It looks better when clicking to it from the other site, with the added "Community Blogs" link.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>