### PR TITLE
adding wordpress instructions, post fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,19 @@ of what we collect:
 ```
 
 The tag must be unique (and this is tested), and the feed should be a format
-parseable by [feedparser](https://pythonhosted.org/feedparser/) (most are). 
+parseable by [feedparser](https://pythonhosted.org/feedparser/) (most are).
+
+#### Wordpress
+
+WordPress is a common blogging platform, and so we include notes here for how
+to find a feed for your wordpress blog. If you want to include all content,
+you can usually find a main feed at `https://<yourblog>/feed/`. However, it's
+recommended to create a [tag or category](https://wordpress.org/support/article/wordpress-feeds/#categories-and-tags) 
+feed, in which case you could find the feed at `https://<yourblog>/category/<category>/feed/`. See the linked
+page for more ways that you can generate custom feeds based on tags and categories.
+Once you've added your feed, it's recommended to test generate posts to ensure
+that it's parsed correctly. This is done during the continuous integration,
+but you can also do it locally (see below).
 
 ### 2. Generate Posts
 
@@ -40,7 +52,26 @@ For this reason, we also define this in the context.
 
 The reason this is set up to run with continuous integration is so that the site
 is regularly updated without human intervention. In the case that there is an error,
-the maintainers are notified.
+the maintainers are notified. However, you can test this generation locally, without
+generating any files!
+
+```bash
+$ python script/generate_posts.py _data/authors.yml --output _posts/ --test
+```
+
+It will show you any new folders and files generated without actually doing it.
+
+```bash
+$ python script/generate_posts.py _data/authors.yml --output _posts/ --test
+[TEST] new author folder /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2019-4-22-p=1452.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2019-2-5-p=1446.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2019-1-23-p=1444.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2018-9-26-p=1442.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2018-6-27-p=1423.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2018-6-25-p=1421.md
+Preparing new post: /home/vanessa/Documents/Dropbox/Code/usrse/blog/_posts/dsk/2018-2-8-p=1415.md
+```
 
 ## Development
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,7 @@ layout: default
       <div class="col-lg-8 col-md-10 mx-auto">
 
         <p class="alert alert-primary">
-        This is a crosspost from <a href="{{ page.blog_url }}">{{ page.blog_title }}</a>, {{ page.blog_subtitle }}. 
+        This is a crosspost from <a href="{{ page.blog_url }}">{{ page.blog_title }}</a>{% if page.blog_subtitle %}, {{ page.blog_subtitle }}{% endif %}. 
         See the original post <a href="{{ page.original_url }}">here</a>.</p>
         </a>
 


### PR DESCRIPTION
This pull request will address the following:
 - #12 filenames with ? will have them removed. For wordpress, this means filenames like `YYYY-MM-DD-p=1234.md` which should still render okay. This change is primarily aesthetic for the files themselves
 - Only display a description and comma if the blog has one defined (see #11)
 - adding WordPress feed instructions to the README #8 

I also added a --test command and instructions for running locally, so a user can preview what will be generated with a nightly build.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>