### PR TITLE
changing envar for circle username, removing deployment preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ deploy: &deploy
     else
         echo "Detected trigger, updating GitHub pages!"
         git branch
-        git config user.name "${CIRCLE_USERNAME}"
-        git config user.email "${CIRCLE_USERNAME}@users.noreply.github.com"
+        git config user.name "${CIRCLECI_USERNAME}"
+        git config user.email "${CIRCLECI_USERNAME}@users.noreply.github.com"
         git checkout master
         git pull origin master
         git add ~/repo/_posts/*
@@ -75,13 +75,17 @@ generate_posts: &generate_posts
 
 build_jekyll: &build_jekyll
     name: Jekyll Build
-    command: |              
-        echo "Building RSE Blog for Preview"
-        cp ~/repo/.circleci/circle_urls.sh ~/repo/circle_urls.sh
-        cd ~/repo
-        chmod u+x circle_urls.sh
-        bash circle_urls.sh              
-        bundle exec jekyll build
+    command: |
+        if [ -z "$CIRCLECI_TRIGGER" ]; then
+            echo "Building RSE Blog for Preview"
+            cp ~/repo/.circleci/circle_urls.sh ~/repo/circle_urls.sh
+            cd ~/repo
+            chmod u+x circle_urls.sh
+            bash circle_urls.sh              
+            bundle exec jekyll build
+        else
+            echo "Nightly build detected, preview not needed."
+        fi
 
 jobs:
   build-site:


### PR DESCRIPTION
These are two quick changes for the nightly build! I had set the github username to be `CIRCLE_USERNAME`, one of the [default](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables) envars thinking that it would override the default (empty) given the trigger, however this is not the case - the trigger seems to unset it:
![image](https://user-images.githubusercontent.com/814322/57862015-a6ab0800-77c5-11e9-8ed6-9b9d6027cc92.png)

In the above, the Github email should be set to the username associated with the bot pushing (it's empty). To fix this, I've changed the envar to `CIRCLECI_USERNAME`. I also realized that we don't need to preview built for the automated deployment (less time / use of circle resources) so I added a check for the variable there.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>