### PR TITLE
Add Map of RSEs and RSE Groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ deploy: &deploy
         echo "CIRCLECI_TRIGGER not found, not nightly build, will not deploy."
         exit 0
     else
-        echo "Detected trigger, updating GitHub pages!"    
+        echo "Detected trigger, updating GitHub pages!"
+        git branch
         git config user.name "${CIRCLE_USERNAME}"
         git config user.email "${CIRCLE_USERNAME}@users.noreply.github.com"
         git checkout master
@@ -49,6 +50,7 @@ deploy: &deploy
         git add ~/repo/_posts/*
         git commit -m 'Automated deployment to Github Pages' --allow-empty
         git push origin master
+        echo $?
     fi      
 
 
@@ -75,7 +77,7 @@ build_jekyll: &build_jekyll
     name: Jekyll Build
     command: |              
         echo "Building RSE Blog for Preview"
-        mv ~/repo/.circleci/circle_urls.sh ~/repo/circle_urls.sh
+        cp ~/repo/.circleci/circle_urls.sh ~/repo/circle_urls.sh
         cd ~/repo
         chmod u+x circle_urls.sh
         bash circle_urls.sh              

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,12 @@ install: &install
   command: |
      $HOME/conda/bin/pip install -r ~/repo/.circleci/requirements.txt
 
+test_map: &test_map
+  name: test the metadata required for map
+  command: |
+     $HOME/conda/bin/python -m unittest script.test_mapdata
+
+
 deploy: &deploy
   name: Deploy back to GitHub master, only in the case that CIRCLECI_TRIGGER is found
   command: |
@@ -117,6 +123,7 @@ jobs:
           key: rubygems-v1
           paths:
             - vendor/bundle
+      - run: *test_map
       - run: *generate_posts
       - run: *build_jekyll
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 _site
 Gemfile.lock
 *.gem

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and experiences.
 
 An RSE or related group that has a blog, podcast, or similar feed can add their
 metadata to the [authors.yml](_data/authors.yml) file. Here is an example
-of what we collect:
+of the required fields that we collect:
 
 ```yaml
 - name: "US Research Software Engineer Community"
@@ -21,6 +21,21 @@ of what we collect:
 
 The tag must be unique (and this is tested), and the feed should be a format
 parseable by [feedparser](https://pythonhosted.org/feedparser/) (most are). 
+
+Optionally, if you want to appear in the USRSE map, you can provide an additional
+headshot (a link to a profile or other picture to represent yourself) and a coordinate
+(latitude and longitude):
+
+```yaml
+...
+  feed: http://myblog.com/feed.xml
+  image: https://www.path.com/to/your/headshot.png
+  coord: [6.41010, 50.90680]
+```
+
+The image is not required. If you leave it out, a template will be used.
+See the [authors.yml](_data/authors.yml) for more examples.
+
 
 ### 2. Generate Posts
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ but you can also do it locally (see below).
 
 ## How do I update the map?
 
+If you have already added yourself as an author, see the first bullet below. If you
+want to add yourself and are not in the authors.yml, *or* if you want to add a group, 
+see the second bullet.
+
 ### 1. Add Yourself to the Map
 
-Optionally, if you want to appear in the USRSE map, you can provide an additional
-headshot or avatar (a link to a profile or other picture to represent yourself) and a coordinate
-(latitude and longitude). If you want to include your group or institution, add
-that too (not required):
+If you want to appear in the USRSE map *and you've already added yourself
+as an author*, you can provide an additional headshot or avatar (a link to a 
+profile or other picture to represent yourself) and a coordinate
+(latitude and longitude) to the authors.yml file. If you want to include your 
+group or institution, add that too (not required):
 
 ```yaml
 ...
@@ -66,19 +71,22 @@ See the [authors.yml](_data/authors.yml) for more examples.
 
 You don't need to include that either, if it doesn't work for you.
 
-### 2. Add your Group to the Map
+### 2. Add your Group/Yourself to the Map
 
 If you belong to a group of Research Software Engineers (hooray!), or want
 to add yourself *without contributing to the feed* you can do so by adding
 an entry to the [_data/map.yml](_data/map.yml) file. Specifically, an entire
-should include a Name, Institution, Url, and coordinate. The name could be an individual,
-or the name of a group. Here is an example:
+should include a name, institution, url, type, and coordinate. The name could be an individual,
+or the name of a group. If you are adding yourself as an individual, set the
+type to be "person." If you are adding a group, set the type to be "group."
+Here is an example:
 
 ```yaml
 - name: "Stanford Research Computing Center"
   url: https://srcc.stanford.edu
   coords: [37.424107, -122.166077]
   institution: Stanford University
+  type: group
 ```
 
 You are also free to add an image parameter, in case your group has a logo.

--- a/README.md
+++ b/README.md
@@ -34,21 +34,67 @@ Once you've added your feed, it's recommended to test generate posts to ensure
 that it's parsed correctly. This is done during the continuous integration,
 but you can also do it locally (see below).
 
+## How do I update the map?
+
+### 1. Add Yourself to the Map
+
 Optionally, if you want to appear in the USRSE map, you can provide an additional
-headshot (a link to a profile or other picture to represent yourself) and a coordinate
-(latitude and longitude):
+headshot or avatar (a link to a profile or other picture to represent yourself) and a coordinate
+(latitude and longitude). If you want to include your group or institution, add
+that too (not required):
 
 ```yaml
 ...
   feed: http://myblog.com/feed.xml
   image: https://www.path.com/to/your/headshot.png
   coord: [6.41010, 50.90680]
+  institution: Stanford University Research Computing Center
 ```
+
+> How do I find a latitude and longitude?
+
+You can actually look it up on [Google Maps](http://maps.google.com), and a more direct approach
+is to use [https://www.latlong.net/](https://www.latlong.net/) and enter
+your location by name.
+
+> What if I don't have an image, or don't want to include one?
 
 The image is not required. If you leave it out, a template will be used.
 See the [authors.yml](_data/authors.yml) for more examples.
 
+> What about my group?
 
+You don't need to include that either, if it doesn't work for you.
+
+### 2. Add your Group to the Map
+
+If you belong to a group of Research Software Engineers (hooray!), or want
+to add yourself *without contributing to the feed* you can do so by adding
+an entry to the [_data/map.yml](_data/map.yml) file. Specifically, an entire
+should include a Name, Institution, Url, and coordinate. The name could be an individual,
+or the name of a group. Here is an example:
+
+```yaml
+- name: "Stanford Research Computing Center"
+  url: https://srcc.stanford.edu
+  coords: [37.424107, -122.166077]
+  institution: Stanford University
+```
+
+You are also free to add an image parameter, in case your group has a logo.
+And of course this could apply to an individual too.
+
+### 3. Test your Entry
+
+Other than previewing the site and ensuring that the coordinate shows up in the
+correct spot, you can run unit testing locally to confirm you have the minimum
+required data:
+
+```bash
+$ python -m unittest script.test_mapdata
+```
+
+This test is also run during the continuous integration to catch any errors.
 ### 2. Generate Posts
 
 The posts are generated automatically - we do this by way of a cron job (scheduled

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ as markdown files, with the author tag corresponding to the folder name in [_pos
 If the post is already included, it is skipped over. This is a reasonable task to do,
 because typically feeds only provide the 10 (or a small number) of latest posts.
 
+If you look at the [.circleci/config.yml](.circleci/config.yml) you'll notice that
+this works by way of an environment variable, `CIRCLECI_TRIGGER`. This is added as
+a build context to the workflow that runs nightly, and indicates that a build
+and deploy is desired. Another important note is that the environment during the 
+trigger is not the same as when triggered by a user (via pull request). For example,
+`CIRCLE_USERNAME`, which is normally set, is undefined for the nightly trigger.
+For this reason, we also define this in the context.
+
 The reason this is set up to run with continuous integration is so that the site
 is regularly updated without human intervention. In the case that there is an error,
 the maintainers are notified.

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,15 @@ defaults:
             layout: post
             comments: true
 
+# Navigation
+navbar-links:
+  Home: ""
+  Community:
+    - About: "about"
+    - RSE Map: "map"
+  Posts:
+    - All Posts: "posts"
+    - Archive: "archive"
 
 # Build settings
 permalink   : /:year/:categories/:title/

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -10,6 +10,9 @@
   tag: "vsoch"
   feed: https://vsoch.github.io/usrse-feed.xml
   url: https://vsoch.github.io/
+  coords: [37.424107, -122.166077]
+  image: https://vsoch.github.io/assets/images/avatar.png
+  institution: Stanford University Research Computing Center
 - name: "Daniel S. Katz's blog"
   tag: "dsk"
   feed: https://danielskatzblog.wordpress.com/category/RSE/feed/

--- a/_data/map.yml
+++ b/_data/map.yml
@@ -1,0 +1,51 @@
+# if you want to contribute a feed along with a map entry, please update authors.yml and not this file
+- name: "Stanford Research Computing Center"
+  image: https://pbs.twimg.com/profile_images/1058424139080335360/6_aDaOYw_400x400.jpg
+  url: https://srcc.stanford.edu/about/computing-support-research
+  coords: [37.272040, -121.861260]
+  institution: Stanford University
+- name: Georgia Institute of Technology
+  image: https://www.ece.gatech.edu/sites/all/themes/gt_ece/images/logos/gt-ece-logo.png
+  url: https://www.ece.gatech.edu/
+  coords: [53.416519, -7.901980]
+- name: Los Alamos National Laboratory
+  image: https://upload.wikimedia.org/wikipedia/commons/2/24/Los_Alamos_logo.svg 
+  url: https://www.lanl.gov/
+  coords: [35.838420, -106.314760]
+- name: Massachusetts Institute of Technology
+  image: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/MIT_logo.svg/1280px-MIT_logo.svg.png
+  url: http://www.mit.edu/
+  coords: [42.358181, -71.093086]
+- name: Northwestern University
+  url: https://www.it.northwestern.edu/research/
+  coords: [42.056458, -87.675270]
+  institution: Research Computing Services
+- name: Oak Ridge National Laboratory
+  url: https://www.ornl.gov/
+  coords: [36.443480, -87.732230]
+- name: Research Computing
+  image: https://researchcomputing.princeton.edu/sites/researchcomputing2/files/tiger-2018cutout-turncatedface-final-4_0.jpg
+  url: https://researchcomputing.princeton.edu
+  coords: [40.348240, -74.657980]
+  institution: Princeton University
+- name: Lewis-Siegler Institute for Integrative Genomics 
+  image: https://lsi.princeton.edu/sites/lsi/themes/lsi_zen/logo.png 
+  url: https://lsi.princeton.edu
+  coords: [28.553845, 77.274614]
+  institution: Princeton University
+- name: Center for Digital Humanites
+  image: https://cdh.princeton.edu/static/img/CDH_logo.svg
+  url: https://cdh.princeton.edu
+  coords: [40.348240, -74.657980]
+  institution: Princeton University
+- name: University of Alabama
+  url: http://cs.ua.edu/research/
+  coords: [33.214024, -87.539139]
+- name: National Center for Supercomputing Applications 
+  url: https://ssa.ncsa.illinois.edu/
+  coords: [28.614920, 77.221730]
+  institution: University of Illinois Urbana-Champaign
+- name: Center for Research Computing
+  url: https://crc.nd.edu/
+  coords: [41.705570, -86.235336]
+  institution: University of Notre Dame

--- a/_data/map.yml
+++ b/_data/map.yml
@@ -4,48 +4,60 @@
   url: https://srcc.stanford.edu/about/computing-support-research
   coords: [37.272040, -121.861260]
   institution: Stanford University
+  type: group
 - name: Georgia Institute of Technology
   image: https://www.ece.gatech.edu/sites/all/themes/gt_ece/images/logos/gt-ece-logo.png
   url: https://www.ece.gatech.edu/
   coords: [53.416519, -7.901980]
+  type: group
 - name: Los Alamos National Laboratory
   image: https://upload.wikimedia.org/wikipedia/commons/2/24/Los_Alamos_logo.svg 
   url: https://www.lanl.gov/
   coords: [35.838420, -106.314760]
+  type: group
 - name: Massachusetts Institute of Technology
   image: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/MIT_logo.svg/1280px-MIT_logo.svg.png
   url: http://www.mit.edu/
   coords: [42.358181, -71.093086]
+  type: group
 - name: Northwestern University
   url: https://www.it.northwestern.edu/research/
   coords: [42.056458, -87.675270]
   institution: Research Computing Services
+  type: group
 - name: Oak Ridge National Laboratory
   url: https://www.ornl.gov/
   coords: [36.443480, -87.732230]
+  type: group
 - name: Research Computing
   image: https://researchcomputing.princeton.edu/sites/researchcomputing2/files/tiger-2018cutout-turncatedface-final-4_0.jpg
   url: https://researchcomputing.princeton.edu
   coords: [40.348240, -74.657980]
   institution: Princeton University
+  type: group
 - name: Lewis-Siegler Institute for Integrative Genomics 
   image: https://lsi.princeton.edu/sites/lsi/themes/lsi_zen/logo.png 
   url: https://lsi.princeton.edu
   coords: [28.553845, 77.274614]
   institution: Princeton University
+  type: group
 - name: Center for Digital Humanites
   image: https://cdh.princeton.edu/static/img/CDH_logo.svg
   url: https://cdh.princeton.edu
   coords: [40.348240, -74.657980]
   institution: Princeton University
+  type: group
 - name: University of Alabama
   url: http://cs.ua.edu/research/
   coords: [33.214024, -87.539139]
+  type: group
 - name: National Center for Supercomputing Applications 
   url: https://ssa.ncsa.illinois.edu/
   coords: [28.614920, 77.221730]
   institution: University of Illinois Urbana-Champaign
+  type: group
 - name: Center for Research Computing
   url: https://crc.nd.edu/
   coords: [41.705570, -86.235336]
   institution: University of Notre Dame
+  type: group

--- a/_includes/map.html
+++ b/_includes/map.html
@@ -16,7 +16,7 @@ var rseLayer = L.layerGroup(RSEs);
 // Next add groups, and RSEs without feeds
 {% for entry in site.data.map %}{% if entry.coords %}
 var marker = L.marker([{{ entry.coords[0] }}, {{ entry.coords[1] }}]);
-marker.bindPopup("RSE Group<br>{% if entry.image %}<img src='{{ entry.image }}' style='height:30px; float:right'>{% endif %}<a href='{{ entry.url }}'>{{ entry.name }}{% if entry.institution %}<br>{{ entry.institution }}{% endif %}</a>");
+marker.bindPopup("{% if entry.type == 'group' %}RSE Group{% else %}Research Software Engineer{% endif %}<br>{% if entry.image %}<img src='{{ entry.image }}' style='height:30px; float:right'>{% endif %}<a href='{{ entry.url }}'>{{ entry.name }}{% if entry.institution %}<br>{{ entry.institution }}{% endif %}</a>");
 {% if entry.type == "group" %}groups.push(marker);{% else %}RSEs.push(marker);{% endif %}{% endif %}{% endfor %}
 
 // Add them to a layer group

--- a/_includes/map.html
+++ b/_includes/map.html
@@ -17,7 +17,7 @@ var rseLayer = L.layerGroup(RSEs);
 {% for entry in site.data.map %}{% if entry.coords %}
 var marker = L.marker([{{ entry.coords[0] }}, {{ entry.coords[1] }}]);
 marker.bindPopup("RSE Group<br>{% if entry.image %}<img src='{{ entry.image }}' style='height:30px; float:right'>{% endif %}<a href='{{ entry.url }}'>{{ entry.name }}{% if entry.institution %}<br>{{ entry.institution }}{% endif %}</a>");
-groups.push(marker);{% endif %}{% endfor %}
+{% if entry.type == "group" %}groups.push(marker);{% else %}RSEs.push(marker);{% endif %}{% endif %}{% endfor %}
 
 // Add them to a layer group
 var groupLayer = L.layerGroup(groups);

--- a/_includes/map.html
+++ b/_includes/map.html
@@ -1,0 +1,50 @@
+<script>
+
+// Store a list of rses, and groups to add to map
+var RSEs = Array()
+var groups = Array()
+
+// First add authors, optionally with image and institution
+{% for author in site.data.authors %}{% if author.coords %}
+var marker = L.marker([{{ author.coords[0] }}, {{ author.coords[1] }}]);
+marker.bindPopup("Research Software Engineer<br>{% if author.image %}<img src='{{ author.image }}' style='height:30px; float:right'>{% endif %}<a href='{{ author.url }}'>{{ author.name }}{% if author.institution %}<br>{{ author.institution }}{% endif %}</a>");
+RSEs.push(marker);{% endif %}{% endfor %}
+
+// Add them to a layer group
+var rseLayer = L.layerGroup(RSEs);
+
+// Next add groups, and RSEs without feeds
+{% for entry in site.data.map %}{% if entry.coords %}
+var marker = L.marker([{{ entry.coords[0] }}, {{ entry.coords[1] }}]);
+marker.bindPopup("RSE Group<br>{% if entry.image %}<img src='{{ entry.image }}' style='height:30px; float:right'>{% endif %}<a href='{{ entry.url }}'>{{ entry.name }}{% if entry.institution %}<br>{{ entry.institution }}{% endif %}</a>");
+groups.push(marker);{% endif %}{% endfor %}
+
+// Add them to a layer group
+var groupLayer = L.layerGroup(groups);
+
+// Add the layers to the map
+var map = L.map('map-container', {
+    center: [37.6, -95.665],
+    zoom: 4,
+    layers: [rseLayer, groupLayer]
+});
+
+// This is the base tile layer
+basemap = L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+             attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+          }).addTo(map);
+
+// Create objects to name them
+var overlayMaps = {
+    "<span style='color: darkpurple'>RSEs</span>": rseLayer,
+    "<span style='color: darkblue'>RSE Groups</span>": groupLayer
+};
+
+var baseMaps = {
+    "<span style='color: green'>Streets</span>": basemap,
+};
+
+// Add the objects to layer controls
+L.control.layers(baseMaps, overlayMaps).addTo(map);
+
+</script>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,26 +1,35 @@
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
+<!-- Navigation, see links in _config.yml-->
+<nav class="navbar navbar-expand-lg navbar-light fixed-top navbar-custom" id="mainNav">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{"/" | relative_url }}">{{ site.title | escape }}
-    </a>
+      <a class="navbar-brand" href="{{"/" | relative_url }}">{{ site.title | escape }}
+      </a>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
       Menu
       <i class="fa fa-bars"></i>
     </button>
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto">
-        <li class="nav-item">
-          <a class="nav-link" href="{{ site.baseurl }}/">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ site.baseurl }}/about/">About</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ site.baseurl }}/posts/">Posts</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ site.baseurl }}/archive/">Archive</a>
-        </li>
+      {% for link in site.navbar-links %}
+        {% if link[1].first %}
+        <div class="dropdown">
+          <button class="btn dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+               {{ link[0] }}
+          </button>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenu2">
+            {% for childlink in link[1] %}
+              {% for linkparts in childlink %}
+                {% include navbarlink.html link=linkparts %}
+              {% endfor %}
+            {% endfor %}
+          </div>
+        </div>
+        {% else %}
+
+        <a href="{{ linkurl }}">
+           <button class="btn" type="button">{{ link[0] }}</button>
+        </a>
+        {% endif %}
+        {% endfor %}
       </ul>
     </div>
   </div>

--- a/_includes/navbarlink.html
+++ b/_includes/navbarlink.html
@@ -1,0 +1,18 @@
+{% capture before %}{{ include.link[1] | split: "://" | first }}{% endcapture %}
+{% capture after %}{{ include.link[1] | split: "://" | last }}{% endcapture %}
+{% assign internal = true %}
+{% if before != after %}
+  {% if before == "http" or before == "https" %}
+    {% assign internal = false %}
+  {% endif %}
+{% endif %}
+
+{% if internal %}
+  {% capture linkurl %}{{ site.baseurl }}/{{ include.link[1] }}{% endcapture %}
+{% else %}
+  {% capture linkurl %}{{ include.link[1] }}{% endcapture %}
+{% endif %}
+
+<a href="{{ linkurl }}">
+    <button class="dropdown-item btn btn-default" type="button">{{ include.link[0] }}</button>
+</a>

--- a/assets/main.css
+++ b/assets/main.css
@@ -304,6 +304,11 @@ footer {
   border-radius: 0;
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; }
 
+.dropdown-item {
+  cursor: pointer !important;
+  padding: 20px;
+}
+
 .btn-primary {
   background-color: #0085A1;
   border-color: #0085A1; }
@@ -315,3 +320,52 @@ footer {
 .btn-lg {
   font-size: 16px;
   padding: 25px 35px; }
+
+/* Multi-level navigation links */
+.navbar-custom .nav .navlinks-container {
+  position: relative;
+}
+.navbar-custom .nav .navlinks-parent:after {
+  content: " \25BC";
+}
+.navbar-custom .nav .navlinks-children {
+  width: 100%;
+  display: none;
+  word-break: break-word;
+}
+.navbar-custom .nav .navlinks-container .navlinks-children a {
+  display: block;
+  padding: 10px;
+  padding-left: 30px;
+  background-color: {{ site.navbar-children-col }};
+  text-decoration: none !important;
+  border-width: 0 1px 1px 1px;
+  font-weight: normal;
+}
+@media only screen and (max-width: 767px) {
+  .navbar-custom .nav .navlinks-container.show-children {
+    background: rgba(0, 0, 0, 0.2);
+  }
+  .navbar-custom .nav .navlinks-container.show-children .navlinks-children {
+    display: block;
+  }
+}
+@media only screen and (min-width: 768px) {
+  .navbar-custom .nav .navlinks-container {
+    text-align: center;
+  }
+  .navbar-custom .nav .navlinks-container:hover {
+    background: rgba(0, 0, 0, 0.1);
+  }
+  .navbar-custom .nav .navlinks-container:hover .navlinks-children {
+    display: block;
+  }
+  .navbar-custom .nav .navlinks-children {
+    position: absolute;
+  }
+  .navbar-custom .nav .navlinks-container .navlinks-children a {
+    padding-left: 10px;
+    border: 1px solid #eaeaea;
+    border-width: 0 1px 1px;
+  }
+}

--- a/pages/map.md
+++ b/pages/map.md
@@ -9,9 +9,12 @@ permalink: /map/
 .page-heading {
     padding-bottom: 10px !important;
 }
+.container {
+   max-width: 1440px;
+}
 </style>
 
-Where are the RSEs that participate in this community blog on the map?
+<p style='text-align:center'>Where are the RSEs that participate in this community blog on the map?</p>
 
 <div id="map-container" style="height:800px"></div>
 

--- a/pages/map.md
+++ b/pages/map.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: USRSE Map
+description: Where is the Research Software Engineer Community?
+permalink: /map/
+---
+
+<style>
+.page-heading {
+    padding-bottom: 10px !important;
+}
+</style>
+
+Where are the RSEs that participate in this community blog on the map?
+
+<div id="map-container" style="height:800px"></div>
+
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
+      integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+      crossorigin=""/>
+
+<script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
+     integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+     crossorigin=""></script>
+
+{% include map.html %}
+
+<br/>
+<br/>
+Map made with [http://leafletjs.com](http://leafletjs.com), and [Open Streetmap](https://osm.org/), and idea from [DE-RSE](https://github.com/DE-RSE/www). Thank you!

--- a/script/test_mapdata.py
+++ b/script/test_mapdata.py
@@ -35,7 +35,7 @@ class TestMap(unittest.TestCase):
         with open(self.map, 'r') as stream:
             mapdata = yaml.safe_load(stream)
 
-        requireds = ['name', 'coords', 'url']
+        requireds = ['name', 'coords', 'url', 'type']
         for entry in mapdata:
 
             print("Testing %s" % entry)
@@ -46,6 +46,9 @@ class TestMap(unittest.TestCase):
             # Test that url is 200
             response = requests.head(entry['url'])
             self.assertTrue(response.status_code in [200, 300])
+ 
+            # Type must be group or person
+            self.assertTrue(entry['type'] in ['group', 'person'])
 
             # Image must exist
             if 'image' in entry:

--- a/script/test_mapdata.py
+++ b/script/test_mapdata.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Read in the map.yml file to validate each entry. Specifically:
+# A name, url, and coord is required.
+# optional fields are institution, image
+
+import unittest
+import requests
+import yaml
+import os
+
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+print("############################################################## test_map")
+
+class TestMap(unittest.TestCase):
+
+    def setUp(self):
+        self.map = os.path.join(os.path.dirname(here), '_data', 'map.yml')
+         
+       
+    def test_loading_file(self):
+        '''test loading of the yaml file
+        '''
+        print("Testing loading of the map.yml file")
+        self.assertTrue(os.path.exists(self.map))
+        with open(self.map, 'r') as stream:
+            mapdata = yaml.safe_load(stream)
+
+    def test_content(self):
+        '''validate required fields are provided
+        '''
+        print("validate required fields are provided")
+        with open(self.map, 'r') as stream:
+            mapdata = yaml.safe_load(stream)
+
+        requireds = ['name', 'coords', 'url']
+        for entry in mapdata:
+
+            print("Testing %s" % entry)
+            for required in requireds:
+                print('Looking for %s' % required)
+                self.assertTrue(required in entry)
+
+            # Test that url is 200
+            response = requests.head(entry['url'])
+            self.assertTrue(response.status_code in [200, 300])
+
+            # Image must exist
+            if 'image' in entry:
+                response = requests.get(entry['image'])
+                self.assertTrue(response.status_code == 200)
+
+            # Coords must be length 2, and int
+            self.assertTrue(len(entry['coords'])==2)
+            for coord in entry['coords']:
+                self.assertTrue(isinstance(coord, float))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request will add a map for RSEs, and RSE groups. If an individual RSE has added his or her entry to the authors.yml, this can be supplemented with a coordinate. If a group or individual (not wanted to be added to the feed) wants to be added to the map, this can be done with the map.yml file. I've created a layer for each on the map, and also added a test file for the data itself. The map looks like this:

![image](https://user-images.githubusercontent.com/814322/57874420-8a679500-77de-11e9-8efe-b5fd0dc688c8.png)

Notice that you can click to select layers in the upper right (both displayed by default). I've also redone the navigation to have dropdowns, since we now have more than a few links. The "RSE Map" is under the Community tab:

![image](https://user-images.githubusercontent.com/814322/57874491-b4b95280-77de-11e9-8694-e69849c0b712.png)

And the archive is moved to be under posts.