### PR TITLE
adding footer link, header home link, and logo to usrse blog site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ defaults:
 
 # Navigation
 navbar-links:
-  Home: ""
+  Home: "https://us-rse.org/"
   Community:
     - About: "about"
   Posts:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,14 @@
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto">
         <ul class="list-inline text-center">
+          <li class="list-inline-item">
+            <a href="https://us-rse.org/">
+              <span class="fa-stack fa-lg">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="fas fa-home fa-stack-1x fa-inverse"></i>
+              </span>
+            </a>
+          </li>
           {% if site.twitter_username %}
           <li class="list-inline-item">
             <a href="https://www.twitter.com/{{ site.twitter_username }}">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,7 @@
 <!-- Navigation, see links in _config.yml-->
 <nav class="navbar navbar-expand-lg navbar-light fixed-top navbar-custom" id="mainNav">
   <div class="container-fluid">
+   <a class="navbar-brand navbar-brand-logo" href="https://us-rse.org"><img id="logo" alt="logo" src="https://usrse.github.io/assets/img/logo.png"></a>
       <a class="navbar-brand" href="{{"/" | relative_url }}">{{ site.title | escape }}
       </a>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">

--- a/assets/main.css
+++ b/assets/main.css
@@ -67,6 +67,13 @@ img::-moz-selection {
   color: #fff;
   background: transparent; }
 
+@media only screen and (min-width: 992px) {
+  #logo { z-index: 10;
+  position: absolute !important;
+  left: 1px !important;
+  top: 1px !important;}
+}
+
 #mainNav {
   position: absolute;
   border-bottom: 1px solid #e9ecef;
@@ -91,7 +98,9 @@ img::-moz-selection {
       border-bottom: 1px solid transparent;
       background: transparent; }
       #mainNav .navbar-brand {
-        padding: 10px 20px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        padding-left: 65px;
         color: #000; }
         #mainNav .navbar-brand:focus, #mainNav .navbar-brand:hover {
           color: #2196F3 }
@@ -121,8 +130,6 @@ img::-moz-selection {
         transition: transform 0.2s;
         border-bottom: 1px solid white;
         background-color: #e7e7e7; }
-        #mainNav.is-fixed .navbar-brand {
-          color: white; }
           #mainNav.is-fixed .navbar-brand:focus, #mainNav.is-fixed .navbar-brand:hover {
             color: #101c5d; }
         #mainNav.is-fixed .navbar-nav > li.nav-item > a {


### PR DESCRIPTION
This is a quick PR to add better branding to the blog site, and link with the main site (now that the url is shared!)

First, the header has the logo added. It should disappear when the screen gets small.

![image](https://user-images.githubusercontent.com/814322/58882391-23851f80-86aa-11e9-9ad6-d17d8c5bcffa.png)

The home link at the top now links to the actual home, the us-rse.org site.

Finally, the bottom footer has an added link to also go home:

![image](https://user-images.githubusercontent.com/814322/58882438-3c8dd080-86aa-11e9-99b9-d43a3410594e.png)

I thought it might look cleaner with small text and a link below the GitHub button, but since we already have the button I am trying this first.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>